### PR TITLE
fix: Homebridge v2 compatibility (2.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-# DEPRECATED
-
-Since I stopped using Homebridge many years ago, and also haven't had a Nefit Easy for more than 4 years, this plugin is deprecated. It may still work for you, or it may not, but I cannot provide support for it.
-
 # Homebridge Nefit Easy™ plugin
 
-This is a plugin for [Homebridge](https://github.com/nfarina/homebridge) to allow controlling your Nefit Easy™ (aka Worcester Wave™, Junkers Control™) thermostat through iOS' HomeKit.
+This is a plugin for [Homebridge](https://homebridge.io) to allow controlling your Nefit Easy™ (aka Worcester Wave™, Junkers Control™) thermostat through Apple HomeKit.
 
 Uses the [`nefit-easy-commands`](https://github.com/robertklep/nefit-easy-commands) module under the hood to communicate with the Nefit/Bosch backend.
 
+## Requirements
+
+* Node.js 20.18.0 or later
+* Homebridge v1.8.0 or later, including Homebridge v2
+
 ## Installation
 
-_This library requires Node.js 6.0.0 or later!_
+Search for `homebridge-nefit-easy` on the Plugins tab of the Homebridge UI, or install it from the command line:
 
 ```
 $ npm i homebridge-nefit-easy -g

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 const NefitEasyClient = require('nefit-easy-commands');
-var Service, Characteristic;
+var Service, Characteristic, HapStatusError, HAPStatus;
 var deviceClient;
 
 module.exports = function(homebridge) {
   Service        = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
+  HapStatusError = homebridge.hap.HapStatusError;
+  HAPStatus      = homebridge.hap.HAPStatus;
 
   homebridge.registerAccessory('homebridge-nefit-easy', 'NefitEasy', NefitEasyAccessory);
   homebridge.registerAccessory('homebridge-nefit-easy', 'NefitEasyOutdoorTemp', NefitEasyAccessoryOutdoorTemp);
@@ -31,15 +33,17 @@ function NefitEasyAccessory(log, config) {
   }
 
   this.serialNumber = creds.serialNumber;
+  this.lastKnown    = {};
   this.service = new Service.Thermostat(this.name);
 
   if (typeof deviceClient === 'undefined') {
     deviceClient  = NefitEasyClient(creds);
   }
 
-  // Establish connection with device.
+  // Establish connection with device. Throwing from here would be an unhandled
+  // rejection, which terminates the Homebridge process on Node 20+.
   deviceClient.connect().catch((e) => {
-    throw Error(e);
+    this.log.error('Failed to connect to Nefit Easy device:', e.message || e);
   });
 
   this.service
@@ -79,6 +83,7 @@ const nefitEasyGetTemp = async function(type, prop, skipOutdoor) {
     const temp = status[prop];
     if (!isNaN(temp) && isFinite(temp)) {
       this.log.debug('...%s temperature is %s', type, temp);
+      this.lastKnown[prop] = temp;
       return temp;
     }
 
@@ -88,20 +93,26 @@ const nefitEasyGetTemp = async function(type, prop, skipOutdoor) {
     const newTemp = newStatus[prop];
     if (!isNaN(newTemp) && isFinite(newTemp)) {
       this.log.debug('Retry request for temperature resulted in valid value: %s', newTemp);
+      this.lastKnown[prop] = newTemp;
       return newTemp;
     }
 
     this.log.debug('Retry request for temperature resulted in invalid value again: %s', newTemp);
 
-    // Return last known value, needed to keep service responsive for Siri.
-    if (prop === 'in house temp' || prop === 'outdoor temp') {
-      return this.service.getCharacteristic(Characteristic.CurrentTemperature).value;
-    } else if (prop === 'temp setpoint') {
-      return this.service.getCharacteristic(Characteristic.TargetTemperature).value;
+    // Return last known value, needed to keep service responsive for Siri. Tracked
+    // separately because the characteristic itself defaults to 0, which would be
+    // reported as a real 0°C reading before the first successful poll.
+    if (prop in this.lastKnown) {
+      return this.lastKnown[prop];
     }
+
+    throw new HapStatusError(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
   } catch (e) {
-    console.error(e);
-    throw e;
+    if (e instanceof HapStatusError) {
+      throw e;
+    }
+    this.log.error('Error getting %s temperature:', type, e.message || e);
+    throw new HapStatusError(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
   }
 };
 
@@ -112,7 +123,12 @@ NefitEasyAccessory.prototype.setTemperature = async function(temp) {
   temp = Math.round(temp * 2) / 2;
 
   this.log.info('Setting temperature to %s', temp);
-  await deviceClient.setTemperature(temp);
+  try {
+    await deviceClient.setTemperature(temp);
+  } catch (e) {
+    this.log.error('Error setting temperature:', e.message || e);
+    throw new HapStatusError(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+  }
 };
 
 NefitEasyAccessory.prototype.getCurrentState = async function() {
@@ -126,8 +142,8 @@ NefitEasyAccessory.prototype.getCurrentState = async function() {
     return isHeating ? Characteristic.CurrentHeatingCoolingState.HEAT :
                        Characteristic.CurrentHeatingCoolingState.OFF;
   } catch (e) {
-    console.error(e);
-    throw e;
+    this.log.error('Error getting current state:', e.message || e);
+    throw new HapStatusError(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
   }
 };
 
@@ -145,15 +161,17 @@ function NefitEasyAccessoryOutdoorTemp(log, config) {
   }
 
   this.serialNumber = creds.serialNumber;
+  this.lastKnown    = {};
   this.service = new Service.TemperatureSensor(this.name);
 
   if (typeof deviceClient === 'undefined') {
     deviceClient  = NefitEasyClient(creds);
   }
 
-  // Establish connection with device.
+  // Establish connection with device. Throwing from here would be an unhandled
+  // rejection, which terminates the Homebridge process on Node 20+.
   deviceClient.connect().catch((e) => {
-    throw Error(e);
+    this.log.error('Failed to connect to Nefit Easy device:', e.message || e);
   });
 
   this.service

--- a/index.js
+++ b/index.js
@@ -44,22 +44,22 @@ function NefitEasyAccessory(log, config) {
 
   this.service
     .getCharacteristic(Characteristic.TemperatureDisplayUnits)
-    .on('get', (callback) => callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS))
-    .setProps({validValues: [Characteristic.TemperatureDisplayUnits.CELSIUS]});;
+    .onGet(() => Characteristic.TemperatureDisplayUnits.CELSIUS)
+    .setProps({validValues: [Characteristic.TemperatureDisplayUnits.CELSIUS]});
 
   this.service
     .getCharacteristic(Characteristic.CurrentTemperature)
-    .on('get', this.getTemperature.bind(this, 'current', 'in house temp', true));
+    .onGet(this.getTemperature.bind(this, 'current', 'in house temp', true));
 
   this.service
     .getCharacteristic(Characteristic.TargetTemperature)
-    .on('get', this.getTemperature.bind(this, 'target', 'temp setpoint', true))
-    .on('set', this.setTemperature.bind(this))
+    .onGet(this.getTemperature.bind(this, 'target', 'temp setpoint', true))
+    .onSet(this.setTemperature.bind(this))
     .setProps({minValue: 5, maxValue: 30, minStep: 0.5});
 
   this.service
     .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-    .on('get', this.getCurrentState.bind(this))
+    .onGet(this.getCurrentState.bind(this))
     .setProps(
       {validValues: [Characteristic.CurrentHeatingCoolingState.OFF,
                      Characteristic.CurrentHeatingCoolingState.HEAT]
@@ -67,77 +67,68 @@ function NefitEasyAccessory(log, config) {
 
   this.service
     .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-    .on('get', (callback) => callback(null, Characteristic.TargetHeatingCoolingState.AUTO))
+    .onGet(() => Characteristic.TargetHeatingCoolingState.AUTO)
     .setProps({validValues: [Characteristic.TargetHeatingCoolingState.AUTO]});
 };
 
-const nefitEasyGetTemp = function(type, prop, skipOutdoor, callback) {
+const nefitEasyGetTemp = async function(type, prop, skipOutdoor) {
   this.log.debug('Getting %s temperature...', type);
 
-  deviceClient.status(skipOutdoor).then((status) => {
-    var temp = status[prop];
+  try {
+    const status = await deviceClient.status(skipOutdoor);
+    const temp = status[prop];
     if (!isNaN(temp) && isFinite(temp)) {
       this.log.debug('...%s temperature is %s', type, temp);
-      return callback(null, temp);
+      return temp;
     }
-    else {
-      this.log.debug('Request for temperature resulted in invalid value: %s', temp);
 
-      // Try one more time, this almost always results in a valid value.
-      deviceClient.status(skipOutdoor).then((newStatus) => {
-        var newTemp = newStatus[prop];
-        if (!isNaN(newTemp) && isFinite(newTemp)) {
-          this.log.debug("Retry request for temperature resulted in valid value: %s", newTemp);
-          return callback(null, newTemp);
-        }
-        else {
-          this.log.debug("Retry request for temperature resulted in invalid value again: %s", newTemp);
-
-          // Return last known value, needed to keep service responsive for Siri.
-          if (prop == 'in house temp' || prop == 'outdoor temp') {
-            return callback(null, this.service.getCharacteristic(Characteristic.CurrentTemperature).value);
-          }
-          else if (prop == 'temp setpoint') {
-            return callback(null, this.service.getCharacteristic(Characteristic.TargetTemperature).value);
-          }
-        }
-      });
+    // Try one more time, this almost always results in a valid value.
+    this.log.debug('Request for temperature resulted in invalid value: %s', temp);
+    const newStatus = await deviceClient.status(skipOutdoor);
+    const newTemp = newStatus[prop];
+    if (!isNaN(newTemp) && isFinite(newTemp)) {
+      this.log.debug('Retry request for temperature resulted in valid value: %s', newTemp);
+      return newTemp;
     }
-  }).catch((e) => {
+
+    this.log.debug('Retry request for temperature resulted in invalid value again: %s', newTemp);
+
+    // Return last known value, needed to keep service responsive for Siri.
+    if (prop === 'in house temp' || prop === 'outdoor temp') {
+      return this.service.getCharacteristic(Characteristic.CurrentTemperature).value;
+    } else if (prop === 'temp setpoint') {
+      return this.service.getCharacteristic(Characteristic.TargetTemperature).value;
+    }
+  } catch (e) {
     console.error(e);
-    return callback(e);
-  });
+    throw e;
+  }
 };
 
 NefitEasyAccessory.prototype.getTemperature = nefitEasyGetTemp;
 
-NefitEasyAccessory.prototype.setTemperature = function(temp, callback) {
+NefitEasyAccessory.prototype.setTemperature = async function(temp) {
   // Round off to nearest half/full.
   temp = Math.round(temp * 2) / 2;
 
   this.log.info('Setting temperature to %s', temp);
-  deviceClient.setTemperature(temp).then(() => {
-    return callback();
-  }).catch((e) => {
-    return callback(e);
-  });
+  await deviceClient.setTemperature(temp);
 };
 
-NefitEasyAccessory.prototype.getCurrentState = function(callback) {
+NefitEasyAccessory.prototype.getCurrentState = async function() {
   this.log.debug('Getting current state..');
 
-  deviceClient.status(true).then((status) => {
-    var state     = status['boiler indicator'];
-    var isHeating = state === 'central heating';
+  try {
+    const status = await deviceClient.status(true);
+    const state = status['boiler indicator'];
+    const isHeating = state === 'central heating';
     this.log.debug('...current state is', state);
-    return callback(null,
-      isHeating ? Characteristic.CurrentHeatingCoolingState.HEAT :
-                  Characteristic.CurrentHeatingCoolingState.OFF
-    );
-  }).catch((e) => {
+    return isHeating ? Characteristic.CurrentHeatingCoolingState.HEAT :
+                       Characteristic.CurrentHeatingCoolingState.OFF;
+  } catch (e) {
     console.error(e);
-    return callback(e);
-  });
+    throw e;
+  }
 };
 
 NefitEasyAccessory.prototype.getServices = nefitEasyServices;
@@ -167,7 +158,7 @@ function NefitEasyAccessoryOutdoorTemp(log, config) {
 
   this.service
     .getCharacteristic(Characteristic.CurrentTemperature)
-    .on('get', this.getTemperature.bind(this, 'outdoor', 'outdoor temp', false));
+    .onGet(this.getTemperature.bind(this, 'outdoor', 'outdoor temp', false));
 };
 
 NefitEasyAccessoryOutdoorTemp.prototype.getTemperature = nefitEasyGetTemp;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "homebridge-nefit-easy",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-nefit-easy",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "nefit-easy-commands": "^3.0.5"
       },
       "engines": {
-        "homebridge": ">=0.2.0",
-        "node": ">=6.0.0"
+        "homebridge": "^1.8.0 || ^2.0.0",
+        "node": "^20.18.0 || ^22.10.0 || ^24.0.0"
       }
     },
     "node_modules/@xmpp/jid": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "bosch"
   ],
   "engines": {
-    "node": ">=6.0.0",
-    "homebridge": ">=0.2.0"
+    "node": ">=18.0.0",
+    "homebridge": "^1.6.0 || ^2.0.0"
   },
   "repository": "robertklep/homebridge-nefit-easy",
   "author": "Robert Klep <robert@klep.name>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-nefit-easy",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Homebridge plugin for Nefit Easy™ (aka Worcester Wave™, Junkers Control™)",
   "main": "index.js",
   "keywords": [
@@ -11,10 +11,14 @@
     "bosch"
   ],
   "engines": {
-    "node": ">=18.0.0",
-    "homebridge": "^1.6.0 || ^2.0.0"
+    "node": "^20.18.0 || ^22.10.0 || ^24.0.0",
+    "homebridge": "^1.8.0 || ^2.0.0"
   },
-  "repository": "robertklep/homebridge-nefit-easy",
+  "repository": "homebridge-plugins/homebridge-nefit-easy",
+  "bugs": {
+    "url": "https://github.com/homebridge-plugins/homebridge-nefit-easy/issues"
+  },
+  "homepage": "https://github.com/homebridge-plugins/homebridge-nefit-easy#readme",
   "author": "Robert Klep <robert@klep.name>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary

Makes the plugin work again on Homebridge v2, and refreshes the package for maintenance under `homebridge-plugins`. Releases as **2.4.0** — no configuration changes are required, existing `config.json` entries keep working.

### Homebridge v2 compatibility

- Replace every `.on('get', callback)` / `.on('set', callback)` handler with `.onGet()` / `.onSet()`. The EventEmitter-style API was removed in Homebridge v2 / HAP-NodeJS v1, which made every characteristic return "No Response" in HomeKit.
- Convert `nefitEasyGetTemp`, `setTemperature` and `getCurrentState` from callback-style to `async`/`await`.

### Error handling

- **Crash fix**: `deviceClient.connect().catch(e => { throw Error(e) })` rethrew from inside a `.catch()`, producing an unhandled rejection. On Node 20+ that terminates the Homebridge process. It now logs the failure and lets the characteristic handlers report it.
- **Fabricated 0°C fix**: the NaN fallback read the last value back off the characteristic, but HAP initialises `CurrentTemperature` to `0`. If the very first poll returned NaN, the plugin reported a real-looking 0°C. The last known good value is now tracked per property, and a genuine "no value yet" surfaces as `SERVICE_COMMUNICATION_FAILURE`.
- Failures now throw `HapStatusError(SERVICE_COMMUNICATION_FAILURE)` instead of a raw error, so HomeKit shows "No Response" cleanly rather than Homebridge logging a stack trace.
- Errors go through the Homebridge logger instead of `console.error`.

### Packaging

- `engines.node` → `^20.18.0 || ^22.10.0 || ^24.0.0` (Homebridge v2's baseline; the previous `>=18` was too permissive).
- `engines.homebridge` → `^1.8.0 || ^2.0.0`.
- `repository`, `bugs` and `homepage` now point at `homebridge-plugins/homebridge-nefit-easy` instead of the original author's repo.
- Removed the deprecation notice from the README and documented the current Node/Homebridge requirements.
- Version bumped to 2.4.0 in `package.json` and `package-lock.json`.

## Test plan

Verified against the real `hap-nodejs` API with a stubbed `nefit-easy-commands` client — 18 checks, all passing:

- Both accessories register; all five characteristics resolve through `handleGetRequest()`
- Target temperature rounds to half degrees
- A NaN reading triggers exactly one retry and returns the retried value
- After a successful read, later NaN readings fall back to the last good value
- A NaN reading with no prior value throws `SERVICE_COMMUNICATION_FAILURE` rather than returning 0
- A failing `connect()` is logged and does not crash the process
- Failing `status()` / `setTemperature()` surface as `SERVICE_COMMUNICATION_FAILURE`
- The outdoor accessory requests outdoor data (`skipOutdoor === false`) and returns it
- Missing credentials still throw a clear configuration error

`npm ci` and the workflow's `npm run lint --if-present` step both pass.

## Notes

- `npm audit` reports 9 advisories, all transitive through `nefit-easy-commands@3.0.5` → `nefit-easy-core` → `request`. There is no newer `nefit-easy-commands` (last published 2022), so they cannot be resolved from here; forcing overrides risks breaking the only working transport. Worth revisiting when the plugin moves off `request`.
- A TypeScript dynamic-platform rewrite (with `config.schema.json` for UI configuration) is parked on `feat/typescript-platform-rewrite` as a candidate 3.0.0. It changes the config format, so it is deliberately kept out of this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
