### PR TITLE
ci: allow the transitive remote tarball dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # See the note in release.yml: a transitive GitHub tarball dependency needs
+      # allow-remote, which npm 12 defaults to none.
       - name: Install dependencies
-        run: npm install
+        run: npm install --allow-remote=all
 
   eslint:
     uses: homebridge/.github/.github/workflows/eslint.yml@latest
+    with:
+      install_cmd: npm ci --allow-remote=all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ permissions:
 jobs:
   eslint:
     uses: homebridge/.github/.github/workflows/eslint.yml@latest
+    with:
+      # See the "Install dependencies" step below.
+      install_cmd: npm ci --allow-remote=all
 
   publish:
     if: ${{ github.repository == 'homebridge-plugins/homebridge-nefit-easy' }}
@@ -56,8 +59,14 @@ jobs:
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
 
+      # nefit-easy-commands depends, via node-xmpp-core, on a GitHub tarball of
+      # reconnect-core. npm 12 refuses remote dependencies unless allow-remote is
+      # set. The tarball is a fork carrying an `opts.emitter` option that
+      # node-xmpp-core requires and the published reconnect-core lacks, so it
+      # cannot be overridden with a registry version without breaking the
+      # connection to the Bosch backend.
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --allow-remote=all
 
       - name: Determine release type
         id: release-type


### PR DESCRIPTION
## Problem

The `publish` job of the 2.4.0 beta release failed at `npm ci`:

```
npm error code EALLOWREMOTE
npm error Fetching packages of type "remote" have been disabled
npm error Refusing to fetch "reconnect-core@https://github.com/dodo/reconnect-core/tarball/merged"
```

The release workflow runs `npm install -g npm@latest` for OIDC support, which now pulls npm 12. [npm 12 defaults `allow-remote` to `none`](https://github.com/npm/cli/commit/caa329568d32587e53f6e098f43b550dd2685034), so any dependency resolved from a remote URL is refused.

`nefit-easy-commands` -> `nefit-easy-core` -> `node-xmpp-client` -> `node-xmpp-core` declares `reconnect-core` as a GitHub tarball rather than a registry version.

## Why not override it to a registry version

`reconnect-core` is on npm up to 1.3.0, but the tarball points at a fork whose API differs. `node-xmpp-core/lib/Connection.js` sets `options.emitter = emitter` and relies on `reconnect-core` reusing that emitter:

```js
var emitter = opts.emitter || new EventEmitter()   // fork
var emitter = new EventEmitter()                   // published 1.3.0
```

The fork also emits `connect` where the published version emits `connection`. Overriding to a registry version would silently break the XMPP connection to the Bosch backend, which is the plugin's only transport.

## Change

Pass `--allow-remote=all` to the install steps in `build.yml` and `release.yml`, including the `install_cmd` input of the shared ESLint workflow. Older npm treats the flag as an unknown config and warns rather than failing, so both current and future runners work.

## Note

This is a workaround, not a fix. The same restriction applies to end users: once Homebridge hosts ship npm 12, `npm i homebridge-nefit-easy` will fail for them too, since the remote tarball is in the runtime dependency tree. Resolving that properly means moving off `nefit-easy-commands`/`node-xmpp-client`, which is worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
